### PR TITLE
No sandbox

### DIFF
--- a/notebook_as_pdf/__init__.py
+++ b/notebook_as_pdf/__init__.py
@@ -21,7 +21,12 @@ from nbconvert.exporters import Exporter
 
 async def html_to_pdf(html_file, pdf_file):
     """Convert a HTML file to a PDF"""
-    browser = await launch(handleSIGINT=False, handleSIGTERM=False, handleSIGHUP=False)
+    browser = await launch(
+        handleSIGINT=False,
+        handleSIGTERM=False,
+        handleSIGHUP=False,
+        args=["--no-sandbox"],
+    )
     page = await browser.newPage()
     await page.setViewport(dict(width=994, height=768))
     await page.emulateMedia("screen")

--- a/notebook_as_pdf/__init__.py
+++ b/notebook_as_pdf/__init__.py
@@ -12,20 +12,20 @@ import nbconvert
 
 from pyppeteer import launch
 
-from traitlets import default
+from traitlets import Bool, default
 
 import PyPDF2
 
 from nbconvert.exporters import Exporter
 
 
-async def html_to_pdf(html_file, pdf_file):
+async def html_to_pdf(html_file, pdf_file, pyppeteer_args=None):
     """Convert a HTML file to a PDF"""
     browser = await launch(
         handleSIGINT=False,
         handleSIGTERM=False,
         handleSIGHUP=False,
-        args=["--no-sandbox"],
+        args=pyppeteer_args or [],
     )
     page = await browser.newPage()
     await page.setViewport(dict(width=994, height=768))
@@ -97,7 +97,13 @@ def attach_notebook(pdf_in, pdf_out, notebook):
         pdf.write(fp)
 
 
-async def notebook_to_pdf(notebook, pdf_path, config=None, resources=None, **kwargs):
+async def notebook_to_pdf(
+    notebook,
+    pdf_path,
+    config=None,
+    resources=None,
+    pyppeteer_args=None,
+    **kwargs):
     """Convert a notebook to PDF"""
     if config is None:
         config = {}
@@ -109,7 +115,7 @@ async def notebook_to_pdf(notebook, pdf_path, config=None, resources=None, **kwa
     with tempfile.NamedTemporaryFile(suffix=".html") as f:
         f.write(exported_html.encode())
         f.flush()
-        await html_to_pdf(f.name, pdf_path)
+        await html_to_pdf(f.name, pdf_path, pyppeteer_args)
 
 
 class PDFExporter(Exporter):
@@ -125,6 +131,13 @@ class PDFExporter(Exporter):
 
     export_from_notebook = "PDF via HTML"
     output_mimetype = "application/pdf"
+    no_sandbox = Bool(
+        False,
+        help=(
+            "Whether to disable chrome sandboxing (not recommended, "
+            "but may be necessary if running as root)"
+        ),
+    ).tag(config=True)
 
     @default("file_extension")
     def _file_extension_default(self):
@@ -149,6 +162,7 @@ class PDFExporter(Exporter):
         with tempfile.TemporaryDirectory(suffix="nb-as-pdf") as name:
             pdf_fname = os.path.join(name, "output.pdf")
             pdf_fname2 = os.path.join(name, "output-with-attachment.pdf")
+            pyppeteer_args = ["--no-sandbox"] if self.no_sandbox else None
 
             self.pool.submit(
                 asyncio.run,
@@ -157,6 +171,7 @@ class PDFExporter(Exporter):
                     pdf_fname,
                     config=self.config,
                     resources=resources,
+                    pyppeteer_args=pyppeteer_args,
                     **kwargs,
                 ),
             ).result()


### PR DESCRIPTION
Fixes #7 

This adds a `PDFExporter.no_sandbox` configurable, defaulting to `False`, which allows the user to disable sandboxing.

In the writing of this, I did not once correctly spell "pyppeteer" 